### PR TITLE
Define PHP_FE_END for PHP < 5.3.10

### DIFF
--- a/extension/uprofiler.c
+++ b/extension/uprofiler.c
@@ -37,6 +37,10 @@
 #include "main/SAPI.h"
 #endif
 
+#ifndef PHP_FE_END
+#define PHP_FE_END {NULL, NULL, NULL}
+#endif
+
 /* {{{ arginfo */
 ZEND_BEGIN_ARG_INFO_EX(arginfo_uprofiler_enable, 0, 0, 0)
   ZEND_ARG_INFO(0, flags)


### PR DESCRIPTION
On PHP < 5.3.10, PHP_FE_END is not defined thus uprofile doesn't compile.